### PR TITLE
feature(Breadcrumbs): Add single category breadcrumbs for product pages

### DIFF
--- a/app/components/Link.tsx
+++ b/app/components/Link.tsx
@@ -1,7 +1,7 @@
-import {forwardRef, useMemo} from 'react';
-import type {ReactNode} from 'react';
 import {Link as RemixLink} from '@remix-run/react';
 import type {LinkProps as RemixLinkProps} from '@remix-run/react';
+import {forwardRef, useMemo} from 'react';
+import type {ReactNode} from 'react';
 
 import {useLocale} from '~/hooks';
 

--- a/app/data/graphql/storefront/product.ts
+++ b/app/data/graphql/storefront/product.ts
@@ -91,7 +91,9 @@ export const PRODUCT_FRAGMENT = `#graphql
     tags
     collections(first: 250) {
       nodes {
-        handle
+        id
+        handle,        
+        title,
       }
     }
     featuredImage {

--- a/app/hooks/product/useParsedProductMetafields.ts
+++ b/app/hooks/product/useParsedProductMetafields.ts
@@ -1,9 +1,9 @@
-import {useMemo} from 'react';
 import type {Product} from '@shopify/hydrogen/storefront-api-types';
+import {useMemo} from 'react';
 
-import {parseMetafieldsFromProduct} from '~/lib/utils';
 import {PRODUCT_METAFIELDS_IDENTIFIERS} from '~/lib/constants';
 import type {ParsedMetafields} from '~/lib/types';
+import {parseMetafieldsFromProduct} from '~/lib/utils';
 
 /**
  * Parse metafields from product
@@ -26,7 +26,7 @@ export function useParsedProductMetafields(
       product,
       identifiers: PRODUCT_METAFIELDS_IDENTIFIERS,
     });
-  }, [fetchOnMount, product?.id]);
+  }, [fetchOnMount, product]);
 }
 
 //

--- a/app/lib/constants/product.ts
+++ b/app/lib/constants/product.ts
@@ -14,6 +14,10 @@ export const PRODUCT_METAFIELDS_IDENTIFIERS = [
     namespace: 'custom',
     key: 'featured_title',
   },
+  {
+    namespace: 'custom',
+    key: 'breadcrumbs',
+  },
 ] as MetafieldIdentifier[];
 
 /* Ensure updating this ratio as needed. Required format is 'width/height' */

--- a/app/routes/($locale).products.$handle.tsx
+++ b/app/routes/($locale).products.$handle.tsx
@@ -166,7 +166,7 @@ export default function ProductRoute() {
       initialVariantId={initialSelectedVariant?.id || null}
     >
       <div data-comp={ProductRoute.displayName}>
-        {/* BRILLIANT - */}
+        {/* BRILLIANT HANDLES LOADING OUR SINGLE PRODUCT THAT WE HAVE A CUSTOM SECTION TIED TO OUR BYOP STUFF - */}
         {!BYOP_PRODUCT_HANDLE.includes(product?.handle) && (
           <Product
             product={product}

--- a/modules/brilliant/FeaturedSlider/FeaturedSliderCard.tsx
+++ b/modules/brilliant/FeaturedSlider/FeaturedSliderCard.tsx
@@ -11,7 +11,7 @@ import {AnalyticsEvent} from '~/components/Analytics/constants';
 import {Link} from '~/components/Link';
 import {ProductItemMedia} from '~/components/ProductItem/ProductItemMedia';
 import {Card} from '~/components/ui/card';
-import {useParsedProductMetafields, useProductModal} from '~/hooks';
+import {useParsedProductMetafields} from '~/hooks';
 import {COLOR_OPTION_NAME} from '~/lib/constants';
 import {SelectedVariant} from '~/lib/types';
 //import type {ProductCms} from '~/lib/types';

--- a/modules/brilliant/Product/Product.tsx
+++ b/modules/brilliant/Product/Product.tsx
@@ -2,6 +2,8 @@ import {useProduct} from '@shopify/hydrogen-react';
 import {useEffect, useMemo} from 'react';
 
 //import {ProductMetafields} from './ProductMetafields';
+import {Breadcrumbs} from '../components/Breadcrumbs';
+
 import {ADDITIONAL_VARIANT_NAMES} from './additionalVariantNames';
 import type {ProductProps} from './Product.types';
 import {ProductDetails} from './ProductDetails';
@@ -81,7 +83,10 @@ export function Product({
 
   return (
     <section data-comp="product">
-      <div className="md:px-contained py-6 md:py-10 lg:py-12">
+      <div className="md:px-contained">
+        <div className="mx-auto max-w-screen-xl py-1 pb-4 md:pb-6 lg:pb-8">
+          <Breadcrumbs product={product} />
+        </div>
         <div className="mx-auto grid max-w-screen-xl grid-cols-1 gap-y-5 md:grid-cols-2 md:grid-rows-[auto_1fr] md:gap-y-4">
           {/* mobile header placement */}
           {/* note: remove this component if mobile header shares same placement as desktop */}

--- a/modules/brilliant/components/Breadcrumbs.tsx
+++ b/modules/brilliant/components/Breadcrumbs.tsx
@@ -1,0 +1,53 @@
+import {Product} from '@shopify/hydrogen/storefront-api-types';
+import {ArrowRight, ChevronRight} from 'lucide-react';
+import {useMemo} from 'react';
+
+import {Link} from '~/components/Link';
+import {useParsedProductMetafields} from '~/hooks';
+
+export function Breadcrumbs({product}: {product: Product}) {
+  const metafields = useParsedProductMetafields(product);
+
+  const collectionCrumb = useMemo(() => {
+    const rawFields = metafields?.['custom.breadcrumbs']?.value || undefined;
+    if (rawFields) {
+      const parsedCollection = JSON.parse(rawFields);
+      if (parsedCollection.length) {
+        return parsedCollection[0];
+      }
+    }
+    return undefined;
+  }, [metafields]);
+
+  const collectionCrumbLink = useMemo(() => {
+    //collectionCrumb
+    const collection = product.collections.nodes.find(
+      ({id}) => id === collectionCrumb,
+    );
+    if (collection) {
+      return collection;
+    }
+    return undefined;
+  }, [collectionCrumb, product.collections.nodes]);
+
+  return (
+    <div className="flex pt-2">
+      <Link className="text-primary" to={'/'}>
+        Home
+      </Link>
+      <ChevronRight />
+      {collectionCrumb && collectionCrumbLink && (
+        <>
+          <Link
+            className="text-primary"
+            to={`/collections/${collectionCrumbLink?.handle}`}
+          >
+            {collectionCrumbLink?.title}
+          </Link>
+          <ChevronRight />
+        </>
+      )}
+      {product.title}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds breadcrumbs to product pages, using product metafields custom.breadcrumbs.  Can take an array of breadcrumb collections but right now only handles one level, and product pages only.