### PR TITLE
feature(RelatedProducts): Adds Related Products Module

### DIFF
--- a/modules/brilliant/Product/Product.tsx
+++ b/modules/brilliant/Product/Product.tsx
@@ -1,8 +1,9 @@
 import {useProduct} from '@shopify/hydrogen-react';
-import {useEffect, useMemo, useState} from 'react';
+import {useEffect, useMemo} from 'react';
 
 //import {ProductMetafields} from './ProductMetafields';
 import {Breadcrumbs} from '../components/Breadcrumbs';
+import {RelatedProducts} from '../RelatedProducts';
 
 import {ADDITIONAL_VARIANT_NAMES} from './additionalVariantNames';
 import type {ProductProps} from './Product.types';
@@ -11,7 +12,7 @@ import {ProductHeader} from './ProductHeader';
 import {ProductMarketing} from './ProductMarketing/ProductMarketing';
 import {ProductMedia} from './ProductMedia/ProductMedia';
 
-import {useLocale, useParsedProductMetafields, useSettings} from '~/hooks';
+import {useLocale, useSettings} from '~/hooks';
 import {COLOR_OPTION_NAME} from '~/lib/constants';
 import type {SelectedVariant} from '~/lib/types';
 
@@ -82,72 +83,79 @@ export function Product({
     : 'md:top-[calc(var(--header-height-desktop)+2.5rem)] xl:top-[calc(var(--header-height-desktop)+3rem)]';
 
   return (
-    <section data-comp="product">
-      <div className="md:px-contained">
-        <div className="mx-auto max-w-screen-xl py-1 pb-4 md:pb-6 lg:pb-8">
-          <Breadcrumbs product={product} />
-        </div>
-        <div className="mx-auto grid max-w-screen-xl grid-cols-1 gap-y-5 md:grid-cols-2 md:grid-rows-[auto_1fr] md:gap-y-4">
-          {/* mobile header placement */}
-          {/* note: remove this component if mobile header shares same placement as desktop */}
-          <ProductHeader
-            isMobile
-            isModalProduct={isModalProduct}
-            product={product}
-            selectedVariant={selectedVariant}
-            selectedVariantColor={selectedVariantColor}
-            settings={productSettings}
-          />
+    <>
+      <section data-comp="product">
+        <div className="md:px-contained">
+          <div className="mx-auto max-w-screen-xl py-1 pb-4 md:pb-6 lg:pb-8">
+            <Breadcrumbs product={product} />
+          </div>
+          <div className="mx-auto grid max-w-screen-xl grid-cols-1 gap-y-5 md:grid-cols-2 md:grid-rows-[auto_1fr] md:gap-y-4">
+            {/* mobile header placement */}
+            {/* note: remove this component if mobile header shares same placement as desktop */}
+            <ProductHeader
+              isMobile
+              isModalProduct={isModalProduct}
+              product={product}
+              selectedVariant={selectedVariant}
+              selectedVariantColor={selectedVariantColor}
+              settings={productSettings}
+            />
 
-          <div>
-            <div
-              className={`md:sticky ${
-                isModalProduct ? 'md:top-10 lg:top-12' : stickyTopClass
-              }`}
-            >
-              <ProductMedia
-                product={product}
-                selectedVariant={selectedVariant}
-                selectedVariantColor={selectedVariantColor}
-              />
+            <div>
+              <div
+                className={`md:sticky ${
+                  isModalProduct ? 'md:top-10 lg:top-12' : stickyTopClass
+                }`}
+              >
+                <ProductMedia
+                  product={product}
+                  selectedVariant={selectedVariant}
+                  selectedVariantColor={selectedVariantColor}
+                />
 
-              <hr className="mt-6" />
+                <hr className="mt-6" />
 
-              <ProductMarketing product={product} />
+                <ProductMarketing product={product} />
+              </div>
+            </div>
+
+            <div className="max-md:px-4 md:pl-4 lg:pl-10 xl:pl-16">
+              <div
+                className={`flex flex-col gap-y-4 md:sticky ${
+                  isModalProduct ? 'md:top-10 lg:top-12' : stickyTopClass
+                }`}
+              >
+                {/* desktop header placement */}
+                <ProductHeader
+                  isModalProduct={isModalProduct}
+                  product={product}
+                  selectedVariant={selectedVariant}
+                  selectedVariantColor={selectedVariantColor}
+                  settings={productSettings}
+                />
+
+                <ProductDetails
+                  enabledQuantitySelector={
+                    productSettings?.quantitySelector?.enabled
+                  }
+                  isModalProduct={isModalProduct}
+                  product={product}
+                  selectedVariant={selectedVariant}
+                  bundleConfig={bundleConfig}
+                />
+
+                {/* <ProductMetafields product={product} /> */}
+              </div>
             </div>
           </div>
-
-          <div className="max-md:px-4 md:pl-4 lg:pl-10 xl:pl-16">
-            <div
-              className={`flex flex-col gap-y-4 md:sticky ${
-                isModalProduct ? 'md:top-10 lg:top-12' : stickyTopClass
-              }`}
-            >
-              {/* desktop header placement */}
-              <ProductHeader
-                isModalProduct={isModalProduct}
-                product={product}
-                selectedVariant={selectedVariant}
-                selectedVariantColor={selectedVariantColor}
-                settings={productSettings}
-              />
-
-              <ProductDetails
-                enabledQuantitySelector={
-                  productSettings?.quantitySelector?.enabled
-                }
-                isModalProduct={isModalProduct}
-                product={product}
-                selectedVariant={selectedVariant}
-                bundleConfig={bundleConfig}
-              />
-
-              {/* <ProductMetafields product={product} /> */}
-            </div>
-          </div>
         </div>
-      </div>
-    </section>
+      </section>
+      <section>
+        {!isModalProduct && !isSectionProduct && (
+          <RelatedProducts product={product} />
+        )}
+      </section>
+    </>
   );
 }
 

--- a/modules/brilliant/RelatedProducts/RelatedProducts.tsx
+++ b/modules/brilliant/RelatedProducts/RelatedProducts.tsx
@@ -1,0 +1,173 @@
+import {Product} from '@shopify/hydrogen/storefront-api-types';
+import {useMemo} from 'react';
+import {useInView} from 'react-intersection-observer';
+
+import type {RelatedProductsCmsLink} from './RelatedProducts.types';
+import {RelatedProductsContainer} from './RelatedProductsContainer';
+
+import {useProductMetafields, useProductsByIds} from '~/hooks';
+import type {MetafieldIdentifier} from '~/lib/types';
+
+const RELATED_PRODUCTS_METAFIELD_IDENTIFIERS: MetafieldIdentifier[] = [
+  {namespace: 'custom', key: 'related_products'},
+  {namespace: 'custom', key: 'related_products_heading'},
+  {namespace: 'custom', key: 'related_products_link'},
+  {namespace: 'custom', key: 'related_products_design'},
+];
+
+const DEFAULT_LINK: RelatedProductsCmsLink = {
+  url: '/collections/all',
+  text: 'View All',
+  newTab: false,
+  type: 'isPage',
+};
+
+const isProductGid = (value: unknown): value is string => {
+  return (
+    typeof value === 'string' && value.startsWith('gid://shopify/Product/')
+  );
+};
+
+const parseRelatedProductIds = (
+  rawValue: string | undefined | null,
+): string[] => {
+  if (!rawValue) return [];
+
+  try {
+    const parsedValue = JSON.parse(rawValue);
+
+    if (Array.isArray(parsedValue)) {
+      return [...new Set(parsedValue.filter(isProductGid))];
+    }
+
+    if (isProductGid(parsedValue)) {
+      return [parsedValue];
+    }
+  } catch (error) {
+    if (isProductGid(rawValue)) {
+      return [rawValue];
+    }
+  }
+
+  return [];
+};
+
+const parseLink = (
+  rawValue: string | undefined | null,
+): RelatedProductsCmsLink => {
+  const value = rawValue?.trim();
+  if (!value) return DEFAULT_LINK;
+
+  if (value.startsWith('mailto:')) {
+    return {
+      url: value,
+      text: 'View All',
+      newTab: false,
+      type: 'isEmail',
+    };
+  }
+
+  if (value.startsWith('tel:')) {
+    return {
+      url: value,
+      text: 'View All',
+      newTab: false,
+      type: 'isPhone',
+    };
+  }
+
+  if (value.startsWith('http://') || value.startsWith('https://')) {
+    return {
+      url: value,
+      text: 'View All',
+      newTab: true,
+      type: 'isExternal',
+    };
+  }
+
+  return {
+    url: value,
+    text: 'View All',
+    newTab: false,
+    type: 'isPage',
+  };
+};
+
+const parseDesign = (
+  rawValue: string | undefined | null,
+): 'expanded' | 'normal' => {
+  if (!rawValue) return 'normal';
+
+  const normalizedRaw = rawValue.trim().toLowerCase();
+  if (normalizedRaw === 'expanded') return 'expanded';
+
+  try {
+    const parsedValue = JSON.parse(rawValue);
+
+    if (typeof parsedValue === 'string') {
+      return parsedValue.trim().toLowerCase() === 'expanded'
+        ? 'expanded'
+        : 'normal';
+    }
+
+    if (Array.isArray(parsedValue)) {
+      const firstValue = parsedValue.find(
+        (value): value is string => typeof value === 'string',
+      );
+      return firstValue?.trim().toLowerCase() === 'expanded'
+        ? 'expanded'
+        : 'normal';
+    }
+  } catch (error) {
+    return 'normal';
+  }
+
+  return 'normal';
+};
+
+export function RelatedProducts({product}: {product: Product}) {
+  const {ref, inView} = useInView({
+    rootMargin: '200px',
+    triggerOnce: true,
+  });
+
+  const metafields = useProductMetafields(
+    product.handle,
+    RELATED_PRODUCTS_METAFIELD_IDENTIFIERS,
+  );
+
+  const relatedProductIds = useMemo(() => {
+    return parseRelatedProductIds(
+      metafields?.['custom.related_products']?.value,
+    );
+  }, [metafields]);
+
+  const relatedProducts = useProductsByIds(relatedProductIds, inView);
+
+  const heading = useMemo(() => {
+    const metafieldHeading =
+      metafields?.['custom.related_products_heading']?.value?.trim();
+    return metafieldHeading || 'Related Products';
+  }, [metafields]);
+
+  const design = useMemo(() => {
+    return parseDesign(metafields?.['custom.related_products_design']?.value);
+  }, [metafields]);
+
+  const link = useMemo(() => {
+    return parseLink(metafields?.['custom.related_products_link']?.value);
+  }, [metafields]);
+
+  if (!relatedProductIds.length) return null;
+
+  return (
+    <section className="mt-4 w-full bg-white py-4" ref={ref}>
+      <div className="mx-auto max-w-screen-xl">
+        <RelatedProductsContainer
+          products={relatedProducts}
+          cms={{heading, design, link}}
+        />
+      </div>
+    </section>
+  );
+}

--- a/modules/brilliant/RelatedProducts/RelatedProducts.types.ts
+++ b/modules/brilliant/RelatedProducts/RelatedProducts.types.ts
@@ -1,0 +1,12 @@
+export interface RelatedProductsCmsLink {
+  url: string;
+  text: string;
+  newTab: boolean;
+  type: 'isPage' | 'isExternal' | 'isEmail' | 'isPhone';
+}
+
+export interface RelatedProductsCms {
+  heading: string;
+  design: 'expanded' | 'normal';
+  link: RelatedProductsCmsLink;
+}

--- a/modules/brilliant/RelatedProducts/RelatedProductsCard.tsx
+++ b/modules/brilliant/RelatedProducts/RelatedProductsCard.tsx
@@ -1,0 +1,141 @@
+import {useAnalytics} from '@shopify/hydrogen';
+import {Product} from '@shopify/hydrogen/storefront-api-types';
+import {useCallback, useMemo} from 'react';
+
+import {AddToCart} from '../AddToCart/AddToCart';
+import {ProductItemPrice} from '../ProductItem/ProductItemPrice';
+
+import {getPriorityTag} from './tagPriority';
+
+import {AnalyticsEvent} from '~/components/Analytics/constants';
+import {Link} from '~/components/Link';
+import {ProductItemMedia} from '~/components/ProductItem/ProductItemMedia';
+import {Card} from '~/components/ui/card';
+import {useParsedProductMetafields} from '~/hooks';
+import {COLOR_OPTION_NAME} from '~/lib/constants';
+import {SelectedVariant} from '~/lib/types';
+
+export function RelatedProductsCard({
+  onClick,
+  product,
+  design,
+}: {
+  onClick?: () => void;
+  product: Product;
+  design: 'expanded' | 'normal';
+}) {
+  const {publish, shop} = useAnalytics();
+  const priorityTag = getPriorityTag(product.tags);
+
+  const selectedVariant = useMemo((): SelectedVariant => {
+    return product?.variants?.nodes?.[0];
+  }, [product]);
+
+  const metafields = useParsedProductMetafields(product);
+
+  const productFeaturedTitle = useMemo(
+    () => metafields?.['custom.featured_title']?.value || product.title,
+    [metafields, product.title],
+  );
+
+  const productExtraDescription = useMemo(
+    () => metafields?.['custom.featured_description']?.value,
+    [metafields],
+  );
+
+  const handleClick = useCallback(() => {
+    publish(AnalyticsEvent.PRODUCT_ITEM_CLICKED, {
+      listIndex: 0,
+      product,
+      selectedVariant,
+      searchTerm: false,
+      shop,
+    });
+    if (typeof onClick === 'function') onClick();
+  }, [publish, product, selectedVariant, shop, onClick]);
+
+  const productUrl = useMemo(() => {
+    const productHandle = selectedVariant?.product?.handle;
+    if (!productHandle) return '';
+    const searchParams = new URLSearchParams();
+
+    selectedVariant.selectedOptions.forEach(({name, value}) => {
+      if (name !== COLOR_OPTION_NAME) return;
+      searchParams.set(name, value);
+    });
+
+    return `/products/${productHandle}${
+      searchParams ? `?${searchParams}` : ''
+    }`;
+  }, [selectedVariant]);
+
+  return (
+    <Card className="flex h-full flex-col overflow-hidden rounded-md border bg-white">
+      <div className="relative">
+        {priorityTag && design === 'expanded' && (
+          <div
+            className={`${priorityTag.color} absolute left-2 top-2 z-10 rounded-full px-2 py-1 text-xs`}
+          >
+            {priorityTag.tag}
+          </div>
+        )}
+        <Link
+          aria-label={productFeaturedTitle}
+          to={productUrl}
+          onClick={handleClick}
+        >
+          <ProductItemMedia
+            hasGrouping={false}
+            selectedProduct={product}
+            selectedVariant={selectedVariant}
+          />
+        </Link>
+      </div>
+
+      <div className="flex flex-1 flex-col p-3">
+        {design === 'normal' && productFeaturedTitle && (
+          <Link
+            aria-label={productFeaturedTitle}
+            to={productUrl}
+            onClick={handleClick}
+          >
+            <h3 className="text-base font-normal">{productFeaturedTitle}</h3>
+          </Link>
+        )}
+
+        {design === 'expanded' && productFeaturedTitle && (
+          <Link
+            aria-label={productFeaturedTitle}
+            to={productUrl}
+            onClick={handleClick}
+          >
+            <h3 className="text-lg font-semibold">{productFeaturedTitle}</h3>
+          </Link>
+        )}
+
+        {design === 'expanded' && productExtraDescription && (
+          <p className="mt-1 text-sm text-gray-600">
+            {productExtraDescription}
+          </p>
+        )}
+
+        <div className="flex-1" />
+
+        <div className="flex flex-row items-center justify-between pt-2">
+          <div
+            className={`${design === 'expanded' ? 'text-lg' : 'text-sm'}  font-bold`}
+          >
+            <ProductItemPrice selectedVariant={selectedVariant} />
+          </div>
+          <div>
+            <AddToCart
+              size={`${design === 'expanded' ? 'default' : 'sm'}`}
+              addToCartText="Add to Cart"
+              selectedVariant={selectedVariant}
+            />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/modules/brilliant/RelatedProducts/RelatedProductsContainer.tsx
+++ b/modules/brilliant/RelatedProducts/RelatedProductsContainer.tsx
@@ -1,0 +1,87 @@
+import {Product} from '@shopify/hydrogen/storefront-api-types';
+import {ChevronRightIcon} from 'lucide-react';
+import {useMemo} from 'react';
+
+import type {RelatedProductsCms} from './RelatedProducts.types';
+import {RelatedProductsCard} from './RelatedProductsCard';
+
+import {Link} from '~/components/Link';
+
+export function RelatedProductsContainer({
+  products,
+  cms,
+}: {
+  products: Product[];
+  cms: RelatedProductsCms;
+}) {
+  const numberOfProducts = useMemo(() => products.length, [products.length]);
+  const gridCols = useMemo(
+    () => (numberOfProducts <= 3 ? 'grid-cols-3' : 'grid-cols-4'),
+    [numberOfProducts],
+  );
+  const mobileGrid = useMemo(
+    () => (cms.design === 'expanded' ? 'grid-cols-1' : 'grid-cols-2'),
+    [cms.design],
+  );
+
+  const link = useMemo(() => cms.link, [cms.link]);
+
+  return (
+    <div className="bg-white p-3" data-comp="related-products">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex">
+          <h3 className="text-2xl">{cms.heading}</h3>
+        </div>
+        <div className="flex items-center text-sm">
+          <Link
+            aria-label={cms.link?.text}
+            className=""
+            to={link?.url}
+            newTab={cms.link?.newTab}
+            type={cms.link?.type}
+          >
+            <div className="flex flex-row items-center justify-center">
+              <div className="">View All</div>
+              <div className="">
+                <ChevronRightIcon size={18} />
+              </div>
+            </div>
+          </Link>
+        </div>
+      </div>
+
+      {products.length === 0 ? (
+        <div className={`grid gap-4 ${mobileGrid} md:${gridCols}`}>
+          {[...Array(cms.design === 'expanded' ? 3 : 4)].map((_, i) => (
+            <div
+              className="flex animate-pulse flex-col overflow-hidden rounded-md border bg-white"
+              key={i}
+            >
+              <div
+                className={` ${cms.design === 'expanded' ? 'h-64' : 'h-48'} bg-gray-300`}
+              />
+              <div className="flex flex-1 flex-col justify-between p-4">
+                <div className="h-4 w-3/4 rounded bg-gray-300" />
+                <div className="mt-2 h-4 w-1/2 rounded bg-gray-300" />
+                <div className="mt-auto flex justify-between pt-4">
+                  <div className="h-4 w-10 rounded bg-gray-300" />
+                  <div className="h-4 w-12 rounded bg-gray-300" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className={`grid gap-4 ${mobileGrid} md:${gridCols}`}>
+          {products.map((relatedProduct) => (
+            <RelatedProductsCard
+              key={relatedProduct.id}
+              product={relatedProduct}
+              design={cms.design}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/modules/brilliant/RelatedProducts/index.tsx
+++ b/modules/brilliant/RelatedProducts/index.tsx
@@ -1,0 +1,1 @@
+export {RelatedProducts} from './RelatedProducts';

--- a/modules/brilliant/RelatedProducts/tagPriority.ts
+++ b/modules/brilliant/RelatedProducts/tagPriority.ts
@@ -1,0 +1,23 @@
+const TAG_META: Record<string, {priority: number; color: string}> = {
+  'Special Edition': {priority: 1, color: 'bg-yellow-400 text-black'},
+  Bestseller: {priority: 2, color: 'bg-red-500 text-white text-shadow'},
+  New: {priority: 3, color: 'bg-green-500 text-white text-shadow'},
+  Featured: {priority: 4, color: 'bg-orange-500 text-white text-shadow'},
+};
+
+export function getPriorityTag(
+  tags: string[] = [],
+): {tag: string; color: string; priority: number} | undefined {
+  const prioritized = tags
+    .filter((tag) => Object.hasOwn(TAG_META, tag))
+    .sort((a, b) => TAG_META[a].priority - TAG_META[b].priority);
+
+  const topTag = prioritized[0];
+  if (!topTag) return undefined;
+
+  return {
+    tag: topTag,
+    color: TAG_META[topTag].color,
+    priority: TAG_META[topTag].priority,
+  };
+}


### PR DESCRIPTION
### Summary
Adds a new standalone PDP module: RelatedProducts under modules/brilliant/RelatedProducts to showcase related products using existing product metafields, without modifying the existing FeaturedSlider CMS integration.

### What Changed
Created new module:
`modules/brilliant/RelatedProducts/RelatedProducts.tsx`
`modules/brilliant/RelatedProducts/RelatedProductsContainer.tsx`
`modules/brilliant/RelatedProducts/RelatedProductsCard.tsx`
`modules/brilliant/RelatedProducts/RelatedProducts.types.ts`
`modules/brilliant/RelatedProducts/tagPriority.ts`
`modules/brilliant/RelatedProducts/index.tsx`

Mounted RelatedProducts below PDP content in:
`modules/brilliant/Product/Product.tsx`

Styled module wrapper as full-width white section with spacing:
`mt-4 w-full bg-white py-4`

### Data Source / Metafields
RelatedProducts reads product metafields client-side via `useProductMetafields`:

`custom.related_products`
`custom.related_products_heading`
`custom.related_products_link`
`custom.related_products_design`

It then fetches referenced products via `useProductsByIds`.

### Design Handling
Supports both:
plain text design value: expanded / normal
list/JSON style values (e.g. ["expanded"])
Expanded card layout uses existing per-product fields already used by cards:
custom.featured_title
custom.featured_description

### Why
Keeps FeaturedSlider and existing CMS/query contracts untouched.
Adds a dedicated, low-risk related-products path for PDP.